### PR TITLE
Updated hcs plan name and versions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "azurerm_marketplace_agreement" "hcs" {
   count     = var.accept_marketplace_aggrement ? 1 : 0
   publisher = "hashicorp-4665790"
   offer     = "hcs-production"
-  plan      = "on-demand"
+  plan      = "on-demand-v2"
 }
 
 resource "azurerm_managed_application" "hcs" {
@@ -52,7 +52,7 @@ resource "azurerm_managed_application" "hcs" {
   managed_resource_group_name = local.managed_resource_group_name
 
   plan {
-    name      = "on-demand"
+    name      = "on-demand-v2"
     product   = "hcs-production"
     publisher = "hashicorp-4665790"
     version   = var.hcs_marketplace_version

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "consul_datacenter_name" {
 variable "consul_version" {
   type        = string
   description = "Select a version of Consul. The only supported value as of April 29, 2020 is v1.7.2"
-  default     = "v1.8.0"
+  default     = "v1.8.4"
 }
 
 variable "external_endpoint" {
@@ -75,7 +75,7 @@ variable "vnet_starting_ip_address" {
 variable "hcs_marketplace_version" {
   type        = string
   description = "Version of the marketplace managed application. No need to change this unless this module is outdated or you know you need to use another version."
-  default     = "0.0.41"
+  default     = "0.0.47"
 }
 
 variable "hcs_base_url" {


### PR DESCRIPTION
The old HCS plan no longer exists.  The change updates to the new plan, the most current version of marketplace and also upgrades consul from 1.8.0 to 1.8.4